### PR TITLE
account for clang-omp being moved to boneyard

### DIFF
--- a/sdpb.rb
+++ b/sdpb.rb
@@ -6,7 +6,7 @@ class Sdpb < Formula
 
   depends_on "gmp"
   depends_on "boost"
-  depends_on "clang-omp"
+  depends_on "homebrew/boneyard/clang-omp"
 
   def install
     ENV['CLANG']="1"


### PR DESCRIPTION
Liam Fitzpatrick pointed out to me that clang-omp has been moved to boneyard. He suggested changing "brew install clang-omp" to "brew install homebrew/boneyard/clang-omp" in the sdpb installation instructions. I assume this file needs to be fixed as well. I have not tested this change.
